### PR TITLE
Making HBO GO videos work with the extension enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+
+# IntelliJ IDEA
+.idea/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **TL;DR: faster playback translates to quick progress, better engagement, and retention.**
 
-Average adult reads prose text at [250 to 300 words per minute](http://www.paperbecause.com/PIOP/files/f7/f7bb6bc5-2c4a-466f-9ae7-b483a2c0dca4.pdf) (wpm). By contrast, the average rate of speech for English speakers is ~150 wpm, with slide presentations often closer to 100 wpm. As a result, when given the choice, many viewers [speed up video playback to ~1.3~1.5 its recorded rate](http://research.microsoft.com/en-us/um/redmond/groups/coet/compression/chi99/paper.pdf) to compensate for the difference.
+Average adult reads prose text at [250 to 300 words per minute](http://www.paperbecause.com/PIOP/files/f7/f7bb6bc5-2c4a-466f-9ae7-b483a2c0dca4.pdf) (wpm). By contrast, the average rate of speech for English speakers is ~150 wpm, with slide presentations often closer to 100 wpm. As a result, when given the choice, many viewers [speed up video playback to ~1.3\~1.5 its recorded rate](http://research.microsoft.com/en-us/um/redmond/groups/coet/compression/chi99/paper.pdf) to compensate for the difference.
 
 Many viewers report that [accelerated viewing keeps their attention longer](http://www.enounce.com/docs/BYUPaper020319.pdf): faster delivery keeps the viewer more engaged with the content. In fact, with a little training many end up watching videos at 2x+ the recorded speed. Some studies report that after being exposed to accelerated playback, [listeners become uncomfortable](http://xenia.media.mit.edu/~barons/html/avios92.html#beasleyalteredspeech) if they are forced to return to normal rate of presentation.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Average adult reads prose text at [250 to 300 words per minute](http://www.paperbecause.com/PIOP/files/f7/f7bb6bc5-2c4a-466f-9ae7-b483a2c0dca4.pdf) (wpm). By contrast, the average rate of speech for English speakers is ~150 wpm, with slide presentations often closer to 100 wpm. As a result, when given the choice, many viewers [speed up video playback to ~1.3\~1.5 its recorded rate](http://research.microsoft.com/en-us/um/redmond/groups/coet/compression/chi99/paper.pdf) to compensate for the difference.
 
-Many viewers report that [accelerated viewing keeps their attention longer](http://www.enounce.com/docs/BYUPaper020319.pdf): faster delivery keeps the viewer more engaged with the content. In fact, with a little training many end up watching videos at 2x+ the recorded speed. Some studies report that after being exposed to accelerated playback, [listeners become uncomfortable](http://xenia.media.mit.edu/~barons/html/avios92.html#beasleyalteredspeech) if they are forced to return to normal rate of presentation.
+Many viewers report that [accelerated viewing keeps their attention longer](http://www.enounce.com/docs/BYUPaper020319.pdf): faster delivery keeps the viewer more engaged with the content. In fact, with a little training many end up watching videos at 2x+ the recorded speed. Some studies report that after being exposed to accelerated playback, [listeners become uncomfortable](http://alumni.media.mit.edu/~barons/html/avios92.html#beasleyalteredspeech) if they are forced to return to normal rate of presentation.
 
 
 ## Faster HTML5 Video

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Many viewers report that [accelerated viewing keeps their attention longer](http
 
 HTML5 video provides a native API to accelerate playback of any video. The problem is, many players either hide, or limit this functionality. For best results playback speed adjustments should be easy and frequent to match the pace and content being covered: we don't read at a fixed speed, and similarly, we need an easy way to accelerate the video, slow it down, and quickly rewind the last point to listen to it a few more times.
 
-![Player](https://lh5.googleusercontent.com/ubqr74funulW1oj_SEDFQBpj_hE26j3aR5G9wfoAZlo1u029_vM9_tlV_f27AvTVWXcB2Hfy81I=s640)
+![Player](https://cloud.githubusercontent.com/assets/2400185/24076745/5723e6ae-0c41-11e7-820c-1d8e814a2888.png)
 
 #### *[Install Chrome Extension](https://chrome.google.com/webstore/detail/video-speed-controller/nffaoalbilbmmfgbnbgppjihopabppdk)*
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The science of accelerated playback
 
-**TL;DR: faster playback translates to quick progress, better engagement, and retention.**
+**TL;DR: faster playback translates to better engagement and retention.**
 
 Average adult reads prose text at [250 to 300 words per minute](http://www.paperbecause.com/PIOP/files/f7/f7bb6bc5-2c4a-466f-9ae7-b483a2c0dca4.pdf) (wpm). By contrast, the average rate of speech for English speakers is ~150 wpm, with slide presentations often closer to 100 wpm. As a result, when given the choice, many viewers [speed up video playback to ~1.3\~1.5 its recorded rate](http://research.microsoft.com/en-us/um/redmond/groups/coet/compression/chi99/paper.pdf) to compensate for the difference.
 
@@ -24,11 +24,7 @@ Once the extension is installed simply navigate to any page that offers HTML5 vi
 * **X** - advance video by 10 seconds.
 * **V** - show/hide the controller.
 
-Note that you can customize these shortcuts in the extension settings page. Also, a few tips for enabling and forcing HTML5 video:
-
- * YouTube: make sure you [enable the HTML5 opt-in experiment](http://www.youtube.com/html5).
- * If you're adventurous, try disabling the Flash plugin in Chrome in chrome://plugins/
- * If viewing a video on Wistia, right click to switch to HTML5 video, refresh the page, and the controls will appear.
+_Note: you can customize these shortcut keys in the extension settings page._
 
 ### FAQ
 

--- a/inject.css
+++ b/inject.css
@@ -24,15 +24,9 @@
 
 /* YouTube embedded player */
 /* e.g. https://www.igvita.com/2012/09/12/web-fonts-performance-making-pretty-fast/ */
-.full-frame .html5-video-player:not(.ytp-fullscreen) .vsc-controller {
+.html5-video-player:not(.ytp-hide-info-bar) .vsc-controller {
   position: relative;
-  top: 45px;
-}
-
-.ytp-fullscreen .vsc-controller {
-  display: block;
-  position: relative;
-  top: 60px;
+  top: 40px;
 }
 
 /* shift controller on vine.co */

--- a/inject.css
+++ b/inject.css
@@ -29,6 +29,12 @@
   top: 40px;
 }
 
+/* Netflix player */
+#netflix-player:not(.player-cinema-mode) .vsc-controller {
+  position: relative;
+  top: 85px;
+}
+
 /* shift controller on vine.co */
 /* e.g. https://vine.co/v/OrJj39YlL57 */
 .video-container .vine-video-container .vsc-controller {

--- a/inject.css
+++ b/inject.css
@@ -29,6 +29,18 @@
   top: 40px;
 }
 
+/* Google Photos player */
+/* Inline preview doesn't have any additional hooks, relying on Aria label */ 
+a[aria-label^="Video"] .vsc-controller {
+  position: relative;
+  top: 35px;
+}
+/* Google Photos full-screen view */
+#player .html5-video-container .vsc-controller {
+  position: relative;
+  top: 50px;
+}
+
 /* Netflix player */
 #netflix-player:not(.player-cinema-mode) .vsc-controller {
   position: relative;

--- a/inject.css
+++ b/inject.css
@@ -36,7 +36,7 @@ a[aria-label^="Video"] .vsc-controller {
   top: 35px;
 }
 /* Google Photos full-screen view */
-#player .html5-video-container .vsc-controller {
+#player:not(.ytd-watch) .html5-video-container .vsc-controller {
   position: relative;
   top: 50px;
 }

--- a/inject.js
+++ b/inject.js
@@ -121,6 +121,13 @@ chrome.extension.sendMessage({}, function(response) {
         </div>
       `;
       shadow.innerHTML = shadowTemplate;
+      shadow.querySelector('#controller').addEventListener('wheel', (e) => {
+        runAction(e.wheelDelta > 0 ? 'faster' : 'slower', document);
+        e.preventDefault();
+        e.stopPropagation();
+      });
+
+
       shadow.querySelector('.draggable').addEventListener('mousedown', (e) => {
         runAction(e.target.dataset['action'], document);
       });

--- a/inject.js
+++ b/inject.js
@@ -296,7 +296,7 @@ chrome.extension.sendMessage({}, function(response) {
         } else if (action === 'faster') {
           // Maximum playback speed in Chrome is set to 16:
           // https://cs.chromium.org/chromium/src/media/blink/webmediaplayer_impl.cc?l=103
-          var s = Math.min(v.playbackRate + tc.settings.speedStep, 16);
+          var s = Math.min( (v.playbackRate < 0.1 ? 0.0 : v.playbackRate) + tc.settings.speedStep, 16);
           v.playbackRate = Number(s.toFixed(2));
         } else if (action === 'slower') {
           // Audio playback is cut at 0.05:

--- a/inject.js
+++ b/inject.js
@@ -4,6 +4,7 @@ chrome.extension.sendMessage({}, function(response) {
       speed: 1.0,           // default 1x
       resetSpeed: 1.0,      // default 1x
       speedStep: 0.1,       // default 0.1x
+      fastSpeed: 1.8,       // default 1.8x
       rewindTime: 10,       // default 10s
       advanceTime: 10,      // default 10s
       resetKeyCode:  82,    // default: R
@@ -12,6 +13,7 @@ chrome.extension.sendMessage({}, function(response) {
       rewindKeyCode: 90,    // default: Z
       advanceKeyCode: 88,   // default: X
       displayKeyCode: 86,   // default: V
+      fastKeyCode: 71,      // default: G
       rememberSpeed: false, // default: false
       startHidden: false,   // default: false
       blacklist: `
@@ -27,12 +29,14 @@ chrome.extension.sendMessage({}, function(response) {
     tc.settings.speed = Number(storage.speed);
     tc.settings.resetSpeed = Number(storage.resetSpeed);
     tc.settings.speedStep = Number(storage.speedStep);
+    tc.settings.fastSpeed = Number(storage.fastSpeed);
     tc.settings.rewindTime = Number(storage.rewindTime);
     tc.settings.advanceTime = Number(storage.advanceTime);
     tc.settings.resetKeyCode = Number(storage.resetKeyCode);
     tc.settings.rewindKeyCode = Number(storage.rewindKeyCode);
     tc.settings.slowerKeyCode = Number(storage.slowerKeyCode);
     tc.settings.fasterKeyCode = Number(storage.fasterKeyCode);
+    tc.settings.fastKeyCode = Number(storage.fastKeyCode);
     tc.settings.displayKeyCode = Number(storage.displayKeyCode);
     tc.settings.advanceKeyCode = Number(storage.advanceKeyCode);
     tc.settings.rememberSpeed = Boolean(storage.rememberSpeed);
@@ -226,6 +230,8 @@ chrome.extension.sendMessage({}, function(response) {
           runAction('reset', document, true)
         } else if (keyCode == tc.settings.displayKeyCode) {
           runAction('display', document, true)
+        } else if (keyCode == tc.settings.fastKeyCode) {
+          runAction('fast', document, true);
         }
 
         return false;
@@ -328,9 +334,15 @@ chrome.extension.sendMessage({}, function(response) {
           controller.classList.toggle('vsc-hidden');
         } else if (action === 'drag') {
           handleDrag(v, controller);
+        } else if (action === 'fast') {
+          playVideoAtFastSpeed(v);
         }
       }
     });
+  }
+
+  function playVideoAtFastSpeed(video) {
+    video.playbackRate = tc.settings.fastSpeed;
   }
 
  function handleDrag(video, controller) {

--- a/inject.js
+++ b/inject.js
@@ -136,12 +136,26 @@ chrome.extension.sendMessage({}, function(response) {
       var fragment = document.createDocumentFragment();
       fragment.appendChild(wrapper);
 
-      // Note: when triggered via a MutationRecord, it's possible that the
-      // target is not the immediate parent. This appends the controller as
-      // the first element of the target, which may not be the parent.
-      this.parent.insertBefore(fragment, this.parent.firstChild);
       this.video.classList.add('vsc-initialized');
       this.video.dataset['vscid'] = this.id;
+
+      switch (location.hostname) {
+        case 'www.amazon.com':
+          // insert before parent to bypass overlay
+          this.parent.parentElement.insertBefore(fragment, this.parent);
+          break;
+
+        case 'www.facebook.com':
+          // set stacking context to same as parent's parent.
+          // + default fallthrough
+          this.parent.style.zIndex = 'auto';
+
+        default:
+          // Note: when triggered via a MutationRecord, it's possible that the
+          // target is not the immediate parent. This appends the controller as
+          // the first element of the target, which may not be the parent.
+          this.parent.insertBefore(fragment, this.parent.firstChild);
+      }
     }
   }
 

--- a/inject.js
+++ b/inject.js
@@ -65,9 +65,6 @@ chrome.extension.sendMessage({}, function(response) {
       });
 
       target.addEventListener('ratechange', function(event) {
-        if (target.readyState === 0) {
-          return;
-        }
         var speed = this.getSpeed();
         this.speedIndicator.textContent = speed;
         tc.settings.speed = speed;

--- a/inject.js
+++ b/inject.js
@@ -50,6 +50,10 @@ chrome.extension.sendMessage({}, function(response) {
 
   function defineVideoController() {
     tc.videoController = function(target, parent) {
+      if (target.dataset['vscid']) {
+        return;
+      }
+
       this.video = target;
       this.parent = target.parentElement || parent;
       this.document = target.ownerDocument;
@@ -244,9 +248,7 @@ chrome.extension.sendMessage({}, function(response) {
       function checkForVideo(node, parent, added) {
         if (node.nodeName === 'VIDEO') {
           if (added) {
-            if (!node.dataset['vscid']) {
-              new tc.videoController(node, parent);
-            }
+            new tc.videoController(node, parent);
           } else {
             if (node.classList.contains('vsc-initialized')) {
               let id = node.dataset['vscid'];

--- a/inject.js
+++ b/inject.js
@@ -69,10 +69,16 @@ chrome.extension.sendMessage({}, function(response) {
       });
 
       target.addEventListener('ratechange', function(event) {
-        var speed = this.getSpeed();
-        this.speedIndicator.textContent = speed;
-        tc.settings.speed = speed;
-        chrome.storage.sync.set({'speed': speed});
+        // Ignore ratechange events on unitialized videos.
+        // 0 == No information is available about the media resource.
+        if (event.target.readyState > 0) {
+          var speed = this.getSpeed();
+          this.speedIndicator.textContent = speed;
+          tc.settings.speed = speed;
+          chrome.storage.sync.set({'speed': speed}, function() {
+            console.log('Speed setting saved: ' + speed);
+          });
+        }
       }.bind(this));
 
       target.playbackRate = tc.settings.speed;

--- a/inject.js
+++ b/inject.js
@@ -312,13 +312,7 @@ chrome.extension.sendMessage({}, function(response) {
           var s = Math.max(v.playbackRate - tc.settings.speedStep, 0.0625);
           v.playbackRate = Number(s.toFixed(2));
         } else if (action === 'reset') {
-          if(v.playbackRate === 1.0) {
-            v.playbackRate = tc.settings.resetSpeed;
-          } else {
-            tc.settings.resetSpeed = v.playbackRate;
-            chrome.storage.sync.set({'resetSpeed': v.playbackRate});
-            v.playbackRate = 1.0;
-          }
+          resetSpeed(v, 1.0);
         } else if (action === 'close') {
           v.classList.add('vsc-cancelled');
           controller.remove();
@@ -328,19 +322,19 @@ chrome.extension.sendMessage({}, function(response) {
         } else if (action === 'drag') {
           handleDrag(v, controller);
         } else if (action === 'fast') {
-          playVideoAtFastSpeed(v);
+          resetSpeed(v, tc.settings.fastSpeed);
         }
       }
     });
   }
 
-  var oldSpeed = 1.0;
-  function playVideoAtFastSpeed(video) {
-    if(video.playbackRate == tc.settings.fastSpeed) {
-      video.playbackRate = oldSpeed;
+  function resetSpeed(v, target) {
+    if (v.playbackRate === target) {
+      v.playbackRate = tc.settings.resetSpeed;
     } else {
-  	  oldSpeed = video.playbackRate;
-      video.playbackRate = tc.settings.fastSpeed;
+      tc.settings.resetSpeed = v.playbackRate;
+      chrome.storage.sync.set({'resetSpeed': v.playbackRate});
+      v.playbackRate = target;
     }
   }
 

--- a/inject.js
+++ b/inject.js
@@ -151,7 +151,7 @@ chrome.extension.sendMessage({}, function(response) {
 
       switch (true) {
         case (location.hostname == 'www.amazon.com'):
-		    case (/www\.hbogo\./).test(location.hostname):
+        case (/www\.hbogo\./).test(location.hostname):
           // insert before parent to bypass overlay
           this.parent.parentElement.insertBefore(fragment, this.parent);
           break;

--- a/inject.js
+++ b/inject.js
@@ -149,14 +149,19 @@ chrome.extension.sendMessage({}, function(response) {
       this.video.classList.add('vsc-initialized');
       this.video.dataset['vscid'] = this.id;
 
-      if (location.hostname == 'www.facebook.com') {
-         // set stacking context to same as parent's parent.
-          // + default fallthrough
-          this.parent.style.zIndex = 'auto';
-      } else if (location.hostname == 'www.amazon.com' || location.hostname.match('www\.hbogo\.*') {
+      switch (true) {
+        case (location.hostname == 'www.amazon.com'):
+		    case (/www\.hbogo\./).test(location.hostname):
           // insert before parent to bypass overlay
           this.parent.parentElement.insertBefore(fragment, this.parent);
-      } else {
+          break;
+
+        case (location.hostname == 'www.facebook.com'):
+          // set stacking context to same as parent's parent.
+          // + default fallthrough
+          this.parent.style.zIndex = 'auto';
+
+        default:
           // Note: when triggered via a MutationRecord, it's possible that the
           // target is not the immediate parent. This appends the controller as
           // the first element of the target, which may not be the parent.

--- a/inject.js
+++ b/inject.js
@@ -56,7 +56,7 @@ chrome.extension.sendMessage({}, function(response) {
       this.id = Math.random().toString(36).substr(2, 9);
       if (!tc.settings.rememberSpeed) {
         tc.settings.speed = 1.0;
-        tc.settings.resetSpeed = 1.0;
+        tc.settings.resetSpeed = tc.settings.fastSpeed;
       }
       this.initializeControls();
 

--- a/inject.js
+++ b/inject.js
@@ -334,8 +334,14 @@ chrome.extension.sendMessage({}, function(response) {
     });
   }
 
+  var oldSpeed = 1.0;
   function playVideoAtFastSpeed(video) {
-    video.playbackRate = tc.settings.fastSpeed;
+    if(video.playbackRate == tc.settings.fastSpeed) {
+      video.playbackRate = oldSpeed;
+    } else {
+  	  oldSpeed = video.playbackRate;
+      video.playbackRate = tc.settings.fastSpeed;
+    }
   }
 
  function handleDrag(video, controller) {

--- a/inject.js
+++ b/inject.js
@@ -125,13 +125,6 @@ chrome.extension.sendMessage({}, function(response) {
         </div>
       `;
       shadow.innerHTML = shadowTemplate;
-      shadow.querySelector('#controller').addEventListener('wheel', (e) => {
-        runAction(e.wheelDelta > 0 ? 'faster' : 'slower', document);
-        e.preventDefault();
-        e.stopPropagation();
-      });
-
-
       shadow.querySelector('.draggable').addEventListener('mousedown', (e) => {
         runAction(e.target.dataset['action'], document);
       });

--- a/inject.js
+++ b/inject.js
@@ -149,18 +149,14 @@ chrome.extension.sendMessage({}, function(response) {
       this.video.classList.add('vsc-initialized');
       this.video.dataset['vscid'] = this.id;
 
-      switch (location.hostname) {
-        case 'www.amazon.com':
-          // insert before parent to bypass overlay
-          this.parent.parentElement.insertBefore(fragment, this.parent);
-          break;
-
-        case 'www.facebook.com':
-          // set stacking context to same as parent's parent.
+      if (location.hostname == 'www.facebook.com') {
+         // set stacking context to same as parent's parent.
           // + default fallthrough
           this.parent.style.zIndex = 'auto';
-
-        default:
+      } else if (location.hostname == 'www.amazon.com' || location.hostname.match('www\.hbogo\.*') {
+          // insert before parent to bypass overlay
+          this.parent.parentElement.insertBefore(fragment, this.parent);
+      } else {
           // Note: when triggered via a MutationRecord, it's possible that the
           // target is not the immediate parent. This appends the controller as
           // the first element of the target, which may not be the parent.

--- a/inject.js
+++ b/inject.js
@@ -195,6 +195,13 @@ chrome.extension.sendMessage({}, function(response) {
   }
 
   function initializeNow(document) {
+      // in theory, this should only run once, in practice..
+      // that's not guaranteed, hence we enforce own init-once.
+      if (document.body.classList.contains('vsc-initialized')) {
+        return;
+      }
+      document.body.classList.add('vsc-initialized');
+
       if (document === window.document) {
         defineVideoController();
       } else {

--- a/inject.js
+++ b/inject.js
@@ -222,7 +222,8 @@ chrome.extension.sendMessage({}, function(response) {
         var keyCode = event.keyCode;
 
         // Ignore if following modifier is active.
-        if (event.getModifierState("Alt")
+        if (!event.getModifierState
+            || event.getModifierState("Alt")
             || event.getModifierState("Control")
             || event.getModifierState("Fn")
             || event.getModifierState("Meta")

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Video Speed Controller",
   "short_name": "videospeed",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "manifest_version": 2,
   "description": "Speed up, slow down, advance and rewind any HTML5 video with quick shortcuts.",
   "homepage_url": "https://github.com/igrigorik/videospeed",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Video Speed Controller",
   "short_name": "videospeed",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "manifest_version": 2,
   "description": "Speed up, slow down, advance and rewind any HTML5 video with quick shortcuts.",
   "homepage_url": "https://github.com/igrigorik/videospeed",

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,6 @@
         "https://plus.google.com/hangouts/*",
         "https://hangouts.google.com/hangouts/*",
         "https://teamtreehouse.com/*",
-        "https://www.lynda.com/*",
         "http://www.hitbox.tv/*"
       ],
       "css": [ "inject.css" ],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Video Speed Controller",
   "short_name": "videospeed",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "manifest_version": 2,
   "description": "Speed up, slow down, advance and rewind any HTML5 video with quick shortcuts.",
   "homepage_url": "https://github.com/igrigorik/videospeed",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Video Speed Controller",
   "short_name": "videospeed",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "manifest_version": 2,
   "description": "Speed up, slow down, advance and rewind any HTML5 video with quick shortcuts.",
   "homepage_url": "https://github.com/igrigorik/videospeed",

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,7 @@
       "exclude_matches": [
         "https://plus.google.com/hangouts/*",
         "https://hangouts.google.com/hangouts/*",
+        "https://meet.google.com/*",
         "https://teamtreehouse.com/*",
         "http://www.hitbox.tv/*"
       ],

--- a/manifest.json
+++ b/manifest.json
@@ -14,10 +14,10 @@
   "options_page": "options.html",
   "browser_action": {
     "default_icon": {
-      "19": "images/icon19.png",
-      "38": "images/icon38.png"
+      "19": "icons/icon19.png",
+      "38": "icons/icon38.png",
+      "48": "icons/icon48.png"
     },
-    "default_icon": "icons/icon48.png",
     "default_popup": "popup.html"
   },
   "content_scripts": [{

--- a/options.html
+++ b/options.html
@@ -33,6 +33,10 @@
         <input id="fasterKeyInput" placeholder="press a key" type="text" value=""/>
       </div>
       <div class="row">
+        <label for="fastKeyInput">Preferred speed</label>
+        <input id="fastKeyInput" placeholder="press a key" type="text" value=""/>
+      </div>
+      <div class="row">
         <label for="displayKeyInput">Show/hide controller</label>
         <input id="displayKeyInput" placeholder="press a key" type="text" value=""/>
       </div>
@@ -55,6 +59,10 @@
       <div class="row">
           <label for="speedStep">Speed Change Step</label>
           <input id="speedStep" type="text" value=""/>
+      </div>
+      <div class="row">
+          <label for="fastSpeed">Preferred Speed (x)</label>
+          <input id="fastSpeed" type="text" value=""/>
       </div>
       <div class="row">
           <label for="rememberSpeed">Remember Playback Speed</label>

--- a/options.js
+++ b/options.js
@@ -3,9 +3,11 @@ var tcDefaults = {
   speedStep: 0.1,       // default 0.1x
   rewindTime: 10,       // default 10s
   advanceTime: 10,      // default 10s
+  fastSpeed: 1.8,       // default 1.8x
   resetKeyCode:  82,    // default: R
   slowerKeyCode: 83,    // default: S
   fasterKeyCode: 68,    // default: D
+  fastKeyCode: 71,      // default: G
   rewindKeyCode: 90,    // default: Z
   advanceKeyCode: 88,   // default: X
   displayKeyCode: 86,   // default: V
@@ -92,11 +94,13 @@ function save_options() {
   var speedStep     = document.getElementById('speedStep').value;
   var rewindTime    = document.getElementById('rewindTime').value;
   var advanceTime   = document.getElementById('advanceTime').value;
+  var fastSpeed     = document.getElementById('fastSpeed').value;
   var resetKeyCode  = document.getElementById('resetKeyInput').keyCode;
   var rewindKeyCode = document.getElementById('rewindKeyInput').keyCode;
   var advanceKeyCode = document.getElementById('advanceKeyInput').keyCode;
   var slowerKeyCode = document.getElementById('slowerKeyInput').keyCode;
   var fasterKeyCode = document.getElementById('fasterKeyInput').keyCode;
+  var fastKeyCode   = document.getElementById('fastKeyInput').keyCode;
   var displayKeyCode = document.getElementById('displayKeyInput').keyCode;
   var rememberSpeed = document.getElementById('rememberSpeed').checked;
   var startHidden = document.getElementById('startHidden').checked;
@@ -105,22 +109,26 @@ function save_options() {
   speedStep     = isNaN(speedStep) ? tcDefaults.speedStep : Number(speedStep);
   rewindTime    = isNaN(rewindTime) ? tcDefaults.rewindTime : Number(rewindTime);
   advanceTime   = isNaN(advanceTime) ? tcDefaults.advanceTime : Number(advanceTime);
+  fastSpeed     = isNaN(fastSpeed) ? tcDefaults.fastSpeed : Number(fastSpeed);
   resetKeyCode  = isNaN(resetKeyCode) ? tcDefaults.resetKeyCode : resetKeyCode;
   rewindKeyCode = isNaN(rewindKeyCode) ? tcDefaults.rewindKeyCode : rewindKeyCode;
   advanceKeyCode = isNaN(advanceKeyCode) ? tcDefaults.advanceKeyCode : advanceKeyCode;
   slowerKeyCode = isNaN(slowerKeyCode) ? tcDefaults.slowerKeyCode : slowerKeyCode;
   fasterKeyCode = isNaN(fasterKeyCode) ? tcDefaults.fasterKeyCode : fasterKeyCode;
+  fastKeyCode   = isNaN(fastKeyCode) ? tcDefaults.fastKeyCode : fastKeyCode;
   displayKeyCode = isNaN(displayKeyCode) ? tcDefaults.displayKeyCode : displayKeyCode;
 
   chrome.storage.sync.set({
     speedStep:      speedStep,
     rewindTime:     rewindTime,
     advanceTime:    advanceTime,
+    fastSpeed:      fastSpeed,
     resetKeyCode:   resetKeyCode,
     rewindKeyCode:  rewindKeyCode,
     advanceKeyCode: advanceKeyCode,
     slowerKeyCode:  slowerKeyCode,
     fasterKeyCode:  fasterKeyCode,
+    fastKeyCode:    fastKeyCode,
     displayKeyCode: displayKeyCode,
     rememberSpeed:  rememberSpeed,
     startHidden:    startHidden,
@@ -141,11 +149,13 @@ function restore_options() {
     document.getElementById('speedStep').value = storage.speedStep.toFixed(2);
     document.getElementById('rewindTime').value = storage.rewindTime;
     document.getElementById('advanceTime').value = storage.advanceTime;
+    document.getElementById('fastSpeed').value = storage.fastSpeed;
     updateShortcutInputText('resetKeyInput',  storage.resetKeyCode);
     updateShortcutInputText('rewindKeyInput', storage.rewindKeyCode);
     updateShortcutInputText('advanceKeyInput', storage.advanceKeyCode);
     updateShortcutInputText('slowerKeyInput', storage.slowerKeyCode);
     updateShortcutInputText('fasterKeyInput', storage.fasterKeyCode);
+    updateShortcutInputText('fastKeyInput', storage.fastKeyCode);
     updateShortcutInputText('displayKeyInput', storage.displayKeyCode);
     document.getElementById('rememberSpeed').checked = storage.rememberSpeed;
     document.getElementById('startHidden').checked = storage.startHidden;
@@ -182,9 +192,11 @@ document.addEventListener('DOMContentLoaded', function () {
   initShortcutInput('advanceKeyInput');
   initShortcutInput('slowerKeyInput');
   initShortcutInput('fasterKeyInput');
+  initShortcutInput('fastKeyInput');
   initShortcutInput('displayKeyInput');
 
   document.getElementById('rewindTime').addEventListener('keypress', inputFilterNumbersOnly);
   document.getElementById('advanceTime').addEventListener('keypress', inputFilterNumbersOnly);
   document.getElementById('speedStep').addEventListener('keypress', inputFilterNumbersOnly);
+  document.getElementById('fastSpeed').addEventListener('keypress', inputFilterNumbersOnly);
 })


### PR DESCRIPTION
I had this problem with the Chrome original extension and found a fix recently.
See https://github.com/igrigorik/videospeed/issues/199
I need to see if the speed is preserved in Firefox. In Chrome I can change the speed but it's reset to 1.0 after a few seconds.