### PR TITLE
fixes speed being reset when toggling fullscreen

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -59,7 +59,7 @@ chrome.runtime.sendMessage({}, function(response) {
       this.document = target.ownerDocument;
       this.id = Math.random().toString(36).substr(2, 9);
       if (!tc.settings.rememberSpeed) {
-        tc.settings.speed = 1.0;
+        tc.settings.speed = target.playbackRate;
         tc.settings.resetSpeed = tc.settings.fastSpeed;
       }
       this.initializeControls();


### PR DESCRIPTION
It seems at some point firefox behavior changed for html5 video such that this function would be called every time fullscreen is toggled, resetting the speed each time --- very frustrating. VSC was resetting it to 1 on this line, and this PR changes it so it maintains the existing speed of the video. It has the side effect of sometimes not resetting the speed at other times when it otherwise should. If there is a way to detect the difference between opening a new video and toggling fullscreen that would likely be useful.

One related problem that remains which I did not bother to fix is the state of the "shadow" indicator being hidden. It will just revert to the default state as defined in the options.

Caveat: I'm no expert, this is the first time I've ever touched JS or web dev, so for all I know I could be breaking something.