### PR TITLE
Manifest Improvements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "Video Speed Controller",
   "short_name": "videospeed",
-  "version": "0.5.9.1",
+  "version": "0.5.9.2",
   "manifest_version": 2,
-  "description": "Speed up, slow down, advance and rewind any HTML5 video with quick shortcuts.",
+  "description": "Speed up, slow down, advance and rewind HTML5 audio/video with shortcuts",
   "homepage_url": "https://github.com/codebicycle/videospeed",
   "browser_specific_settings": {
     "gecko": {
@@ -17,8 +17,7 @@
   },
   "permissions": [ "activeTab", "storage" ],
   "options_ui": {
-    "page": "options.html",
-    "open_in_tab": true
+    "page": "options.html"
   },
   "browser_action": {
     "default_icon": {
@@ -36,8 +35,7 @@
         "https://plus.google.com/hangouts/*",
         "https://hangouts.google.com/*",
         "https://meet.google.com/*",
-        "https://teamtreehouse.com/*",
-        "http://www.hitbox.tv/*"
+        "https://teamtreehouse.com/*"
       ],
       "css": [ "inject.css" ],
       "js":  [ "inject.js" ]


### PR DESCRIPTION
1) Removed deprecated URL.
   a. That old hitbox.tv URL does redirect somewhere else now.  Does that site need to be excluded?
   b. Why are sites excluded here vs. being added to the default exclusions list in Options?
2) Removed "open_in_tab": true
   a. I'm not seeing any reason why Options need to open in a new tab.  Firefox currently makes it a little challenging to find Options that load in a separate tab.  If this is needed, please, by all means, revert that change! :)
3) Shortened description and added "audio"
4) Version bump