### PR TITLE
Fixed controls not showing on youtube videos.

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -281,7 +281,7 @@ function defineVideoController() {
     var wrapper = document.createElement("div");
     wrapper.classList.add("vsc-controller");
 
-    if (!this.video.currentSrc) {
+    if (!this.video.src && !this.video.currentSrc) {
       wrapper.classList.add("vsc-nosource");
     }
 


### PR DESCRIPTION
Only add the nosource class if the video has no src or currentSrc.