### PR TITLE
Seperate lowercase and uppercase input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ local
 .idea/
 node_modules
 
-web-ext-artifacts
+web-ext-artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ local
 # IntelliJ IDEA
 .idea/
 node_modules
+
+web-ext-artifacts

--- a/constants.js
+++ b/constants.js
@@ -24,8 +24,8 @@ export const tcDefaults = {
     { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
   ],
   blacklist: `www.instagram.com
-  twitter.com
-  imgur.com
-  teams.microsoft.com
-  `
+twitter.com
+imgur.com
+teams.microsoft.com
+`
 };

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,28 @@
+// Strips out whitespace before a line, I think
+export const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
+
+// The default values for each setting
+export const tcDefaults = {
+    speed: 1.0, // default speed to play videos
+    displayKey: "v", // is this used?
+    rememberSpeed: false,
+    audioBoolean: false,
+    startHidden: false,
+    forceLastSavedSpeed: false,
+    enabled: true,
+    controllerOpacity: 0.3,
+    keyBindings: [
+      { action: "display", key: "v", value: 0, force: false, predefined: true },
+      { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
+      { action: "faster", key: "d", value: 0.1, force: false, predefined: true },
+      { action: "rewind", key: "z", value: 10, force: false, predefined: true },
+      { action: "advance", key: "x", value: 10, force: false, predefined: true },
+      { action: "reset", key: "r", value: 1, force: false, predefined: true },
+      { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
+    ],
+    blacklist: `www.instagram.com
+  twitter.com
+  imgur.com
+  teams.microsoft.com
+  `
+  };

--- a/constants.js
+++ b/constants.js
@@ -23,7 +23,8 @@ export const tcDefaults = {
     { action: "reset", key: "r", value: 1, force: false, predefined: true },
     { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
   ],
-  blacklist: `www.instagram.com
+  blacklist: `\
+www.instagram.com
 twitter.com
 imgur.com
 teams.microsoft.com

--- a/constants.js
+++ b/constants.js
@@ -1,3 +1,4 @@
+//TODO verify accuracy of and fix this comment
 // Strips out whitespace before a line, I think
 export const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
 

--- a/constants.js
+++ b/constants.js
@@ -3,26 +3,28 @@ export const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
 
 // The default values for each setting
 export const tcDefaults = {
-    speed: 1.0, // default speed to play videos
-    displayKey: "v", // is this used?
-    rememberSpeed: false,
-    audioBoolean: false,
-    startHidden: false,
-    forceLastSavedSpeed: false,
-    enabled: true,
-    controllerOpacity: 0.3,
-    keyBindings: [
-      { action: "display", key: "v", value: 0, force: false, predefined: true },
-      { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
-      { action: "faster", key: "d", value: 0.1, force: false, predefined: true },
-      { action: "rewind", key: "z", value: 10, force: false, predefined: true },
-      { action: "advance", key: "x", value: 10, force: false, predefined: true },
-      { action: "reset", key: "r", value: 1, force: false, predefined: true },
-      { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
-    ],
-    blacklist: `www.instagram.com
+  // The default speed videos should play with
+  speed: 1.0,
+  //TODO is this value used? I don't see why it should be needed, can probably be refactored out?
+  displayKey: "v",
+  rememberSpeed: false,
+  audioBoolean: false,
+  startHidden: false,
+  forceLastSavedSpeed: false,
+  enabled: true,
+  controllerOpacity: 0.3,
+  keyBindings: [
+    { action: "display", key: "v", value: 0, force: false, predefined: true },
+    { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
+    { action: "faster", key: "d", value: 0.1, force: false, predefined: true },
+    { action: "rewind", key: "z", value: 10, force: false, predefined: true },
+    { action: "advance", key: "x", value: 10, force: false, predefined: true },
+    { action: "reset", key: "r", value: 1, force: false, predefined: true },
+    { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
+  ],
+  blacklist: `www.instagram.com
   twitter.com
   imgur.com
   teams.microsoft.com
   `
-  };
+};

--- a/constants.js
+++ b/constants.js
@@ -14,6 +14,7 @@ export const tcDefaults = {
   forceLastSavedSpeed: false,
   enabled: true,
   controllerOpacity: 0.3,
+  controllerSize: "13px",
   keyBindings: [
     { action: "display", key: "v", value: 0, force: false, predefined: true },
     { action: "slower", key: "s", value: 0.1, force: false, predefined: true },

--- a/inject.js
+++ b/inject.js
@@ -11,15 +11,15 @@ teams.microsoft.com
 var tc = {
   settings: {
     lastSpeed: 1.0, // default 1x
-    enabled: true, // default enabled
+    enabled: true,
     speeds: {}, // empty object to hold speed for each source
 
-    displayKey: "v", // default: V
-    rememberSpeed: false, // default: false
-    forceLastSavedSpeed: false, //default: false
-    audioBoolean: false, // default: false
-    startHidden: false, // default: false
-    controllerOpacity: 0.3, // default: 0.3
+    displayKey: "v",
+    rememberSpeed: false,
+    forceLastSavedSpeed: false,
+    audioBoolean: false,
+    startHidden: false,
+    controllerOpacity: 0.3,
     keyBindings: [],
     blacklist: `\
 www.instagram.com

--- a/inject.js
+++ b/inject.js
@@ -1,5 +1,3 @@
-var regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
-
 var tc = {
   settings: {
     lastSpeed: 1.0, // default 1x
@@ -37,24 +35,31 @@ var tc = {
 */
 function log(message, level) {
   verbosity = tc.settings.logLevel;
-  verbosity = 6; //TODO
-  if (typeof level === "undefined") {
-    level = tc.settings.defaultLogLevel;
-  }
+  let to_print = "";
   if (verbosity >= level) {
-    if (level === 2) {
-      console.log("ERROR:" + message);
-    } else if (level === 3) {
-      console.log("WARNING:" + message);
-    } else if (level === 4) {
-      console.log("INFO:" + message);
-    } else if (level === 5) {
-      console.log("DEBUG:" + message);
-    } else if (level === 6) {
-      console.log("DEBUG (VERBOSE):" + message);
-      console.trace();
+    switch (level) {
+      case 2:
+        to_print = "ERROR: ";
+        break;
+      case 3:
+        to_print = "WARNING: ";
+        break;
+      case 4:
+        to_print = "INFO: ";
+        break;
+      case 5:
+        to_print = "DEBUG: ";
+        break;
+      case 6:
+        to_print = "VERBOSE DEBUG: ";
+        console.trace();
+        break;
+      default:
+        console.log("ALERT: Please report how you got this to VideoSpeed");
+        console.trace();
     }
   }
+  console.log("Videospeed: " + to_print + message);
 }
 
 // TODO this has duplicated values from options.js, figure out how to only define information once

--- a/inject.js
+++ b/inject.js
@@ -16,7 +16,6 @@ var tc = {
     blacklist: `\
       www.instagram.com
       twitter.com
-      vine.co
       imgur.com
       teams.microsoft.com
     `.replace(regStrip, ""),
@@ -38,7 +37,7 @@ var tc = {
 */
 function log(message, level) {
   verbosity = tc.settings.logLevel;
-	verbosity = 6; //TODO
+  verbosity = 6; //TODO
   if (typeof level === "undefined") {
     level = tc.settings.defaultLogLevel;
   }
@@ -66,7 +65,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
     // UPDATE
     tc.settings.keyBindings.push({
       action: "slower",
-      key: String(storage.slowerKey) || "s"
+      key: String(storage.slowerKey) || "s",
       value: Number(storage.speedStep) || 0.1,
       force: false,
       predefined: true
@@ -156,9 +155,8 @@ function getKeyBindings(action, what = "value") {
 }
 
 function setKeyBindings(action, value) {
-  tc.settings.keyBindings.find((item) => item.action === action)[
-    "value"
-  ] = value;
+  tc.settings.keyBindings.find((item) => item.action === action)["value"] =
+    value;
 }
 
 function defineVideoController() {
@@ -346,22 +344,23 @@ function defineVideoController() {
     var fragment = document.createDocumentFragment();
     fragment.appendChild(wrapper);
 
-    switch (true) {
-      case location.hostname == "www.amazon.com":
-      case location.hostname == "www.reddit.com":
+    switch (location.hostname) {
+      case "www.amazon.com":
+      case "www.reddit.com":
       case /hbogo\./.test(location.hostname):
         // insert before parent to bypass overlay
         this.parent.parentElement.insertBefore(fragment, this.parent);
         break;
-      case location.hostname == "www.facebook.com":
+      case "www.facebook.com":
         // this is a monstrosity but new FB design does not have *any*
         // semantic handles for us to traverse the tree, and deep nesting
         // that we need to bubble up from to get controller to stack correctly
-        let p = this.parent.parentElement.parentElement.parentElement
-          .parentElement.parentElement.parentElement.parentElement;
+        let p =
+          this.parent.parentElement.parentElement.parentElement.parentElement
+            .parentElement.parentElement.parentElement;
         p.insertBefore(fragment, p.firstChild);
         break;
-      case location.hostname == "tv.apple.com":
+      case "tv.apple.com":
         // insert after parent for correct stacking context
         this.parent.getRootNode().querySelector(".scrim").prepend(fragment);
       default:
@@ -428,8 +427,7 @@ function setupListener() {
   function updateSpeedFromEvent(video) {
     // It's possible to get a rate change on a VIDEO/AUDIO that doesn't have
     // a video controller attached to it.  If we do, ignore it.
-    if (!video.vsc)
-      return;
+    if (!video.vsc) return;
     var speedIndicator = video.vsc.speedIndicator;
     var src = video.currentSrc;
     var speed = Number(video.playbackRate.toFixed(2));
@@ -483,7 +481,7 @@ function initializeWhenReady(document) {
   if (isBlacklisted()) {
     return;
   }
-  window.addEventListener('load', () => {
+  window.addEventListener("load", () => {
     initializeNow(window.document);
   });
   if (document) {
@@ -589,7 +587,7 @@ function initializeNow(document) {
           return false;
         }
 
-        let item = tc.settings.keyBindings.find((item) => item.key === key);
+        var item = tc.settings.keyBindings.find((item) => item.key === key);
         if (item) {
           runAction(item.action, item.value);
           if (item.force === "true") {
@@ -655,8 +653,7 @@ function initializeNow(document) {
                   (x) => x.tagName == "VIDEO"
                 )[0];
                 if (node) {
-                  if (node.vsc)
-                    node.vsc.remove();
+                  if (node.vsc) node.vsc.remove();
                   checkForVideo(node, node.parentNode || mutation.target, true);
                 }
               }

--- a/inject.js
+++ b/inject.js
@@ -293,11 +293,14 @@ function defineVideoController() {
     var shadowTemplate = `
         <style>
           @import "${chrome.runtime.getURL("shadow.css")}";
+          * {
+            font-size: 13px;
+          }
         </style>
 
         <div id="controller" style="top:${top}; left:${left}; opacity:${
       tc.settings.controllerOpacity
-    }">
+    };">
           <span data-action="drag" class="draggable">${speed}</span>
           <span id="controls">
             <button data-action="rewind" class="rw">«</button>

--- a/inject.js
+++ b/inject.js
@@ -1,5 +1,11 @@
 // Firefox is a bad browser, except all the rest - this import is not possible
-import {regStrip, tcDefaults} from "./constants.js";
+//import {regStrip, tcDefaults} from "./constants.js";
+export const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
+export const tcDefaults = { speed: 1.0, displayKey: "v", rememberSpeed: false, audioBoolean: false, startHidden: false, forceLastSavedSpeed: false, enabled: true, controllerOpacity: 0.3, keyBindings: [ { action: "display", key: "v", value: 0, force: false, predefined: true }, { action: "slower", key: "s", value: 0.1, force: false, predefined: true }, { action: "faster", key: "d", value: 0.1, force: false, predefined: true }, { action: "rewind", key: "z", value: 10, force: false, predefined: true }, { action: "advance", key: "x", value: 10, force: false, predefined: true }, { action: "reset", key: "r", value: 1, force: false, predefined: true }, { action: "fast", key: "g", value: 1.8, force: false, predefined: true } ], blacklist: `www.instagram.com
+twitter.com
+imgur.com
+teams.microsoft.com
+` };
 
 //TODO parts of this this may be able to be refactored out by using tcDefaults
 var tc = {

--- a/inject.js
+++ b/inject.js
@@ -21,7 +21,7 @@ var tc = {
     startHidden: false,
     controllerOpacity: 0.3,
     keyBindings: [],
-    blacklist: `\
+    blacklist: `
 www.instagram.com
 twitter.com
 imgur.com
@@ -68,7 +68,7 @@ function log(message, level) {
         console.log("ALERT: Please report how you got this to VideoSpeed");
         console.trace();
     }
-    console.log("Videospeed: " + to_print + message);
+    console.log(to_print + message);
   }
 }
 

--- a/inject.js
+++ b/inject.js
@@ -10,6 +10,7 @@ const tcDefaults = {
   forceLastSavedSpeed: false,
   enabled: true,
   controllerOpacity: 0.3,
+  controllerSize: "13px",
   keyBindings: [
     { action: "display", key: "v", value: 0, force: false, predefined: true },
     { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
@@ -40,6 +41,7 @@ var tc = {
     audioBoolean: false,
     startHidden: false,
     controllerOpacity: 0.3,
+    controllerSize: "13px",
     keyBindings: [],
     blacklist: `\
 www.instagram.com
@@ -113,6 +115,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
     //TODO what does this do?
     tc.settings.version = "0.5.3";
 
+    //TODO we should refactor tc so we can just call chrome.storage.sync.set(tc.settings)
     chrome.storage.sync.set({
       keyBindings: tc.settings.keyBindings,
       version: tc.settings.version,
@@ -123,6 +126,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
       startHidden: tc.settings.startHidden,
       enabled: tc.settings.enabled,
       controllerOpacity: tc.settings.controllerOpacity,
+      controllerSize: tc.settings.controllerSize,
       blacklist: tc.settings.blacklist.replace(regStrip, "")
     });
   }
@@ -134,6 +138,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
   tc.settings.enabled = Boolean(storage.enabled);
   tc.settings.startHidden = Boolean(storage.startHidden);
   tc.settings.controllerOpacity = Number(storage.controllerOpacity);
+  tc.settings.controllerSize = String(storage.controllerSize);
   tc.settings.blacklist = String(storage.blacklist);
 
   initializeWhenReady(document);
@@ -287,7 +292,7 @@ function defineVideoController() {
         <style>
           @import "${chrome.runtime.getURL("shadow.css")}";
           * {
-            font-size: 13px;
+            font-size:${tc.settings.controllerSize};
           }
         </style>
 

--- a/inject.js
+++ b/inject.js
@@ -1,4 +1,5 @@
-//import * as constants from "./constants.js";
+// Firefox is a bad browser, except all the rest - this import is not possible
+//import {regStrip, tcDefaults} from "./constants.js";
 // Strips out whitespace before a line, I think
 const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
 

--- a/inject.js
+++ b/inject.js
@@ -12,11 +12,11 @@ var tc = {
     controllerOpacity: 0.3, // default: 0.3
     keyBindings: [],
     blacklist: `\
-      www.instagram.com
-      twitter.com
-      imgur.com
-      teams.microsoft.com
-    `.replace(regStrip, ""),
+www.instagram.com
+twitter.com
+imgur.com
+teams.microsoft.com
+`,
     defaultLogLevel: 4,
     logLevel: 3
   },
@@ -58,55 +58,75 @@ function log(message, level) {
         console.log("ALERT: Please report how you got this to VideoSpeed");
         console.trace();
     }
+    console.log("Videospeed: " + to_print + message);
   }
-  console.log("Videospeed: " + to_print + message);
+}
+
+// Needed because you cannot || with "undefined". Only used in the next function
+function storageToString(stored_key, default_key) {
+  if (stored_key) {
+    return String(stored_key);
+  } else {
+    return default_key;
+  }
 }
 
 // TODO this has duplicated values from options.js, figure out how to only define information once
+const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
 chrome.storage.sync.get(tc.settings, function (storage) {
   tc.settings.keyBindings = storage.keyBindings; // Array
+
+  console.log(storage);
+
+  // The first time the extension runs...
   if (storage.keyBindings.length == 0) {
-    // if first initialization of 0.5.3
-    // UPDATE
     tc.settings.keyBindings.push({
       action: "slower",
-      key: String(storage.slowerKey) || "s",
+      key: storageToString(storage.slowerKey, "s"),
       value: Number(storage.speedStep) || 0.1,
       force: false,
       predefined: true
     });
     tc.settings.keyBindings.push({
       action: "faster",
-      key: String(storage.fasterKey) || "d",
+      key: storageToString(storage.fasterKey, "d"),
       value: Number(storage.speedStep) || 0.1,
       force: false,
       predefined: true
     });
     tc.settings.keyBindings.push({
       action: "rewind",
-      key: String(storage.rewindKey) || "z",
+      key: storageToString(storage.rewindKey, "z"),
       value: Number(storage.rewindTime) || 10,
       force: false,
       predefined: true
     });
     tc.settings.keyBindings.push({
       action: "advance",
-      key: String(storage.advanceKey) || "x",
+      key: storageToString(storage.advanceKey, "x"),
       value: Number(storage.advanceTime) || 10,
       force: false,
       predefined: true
     });
     tc.settings.keyBindings.push({
       action: "reset",
-      key: String(storage.resetKey) || "r",
+      key: storageToString(storage.resetKey, "r"),
       value: 1.0,
       force: false,
       predefined: true
     });
     tc.settings.keyBindings.push({
       action: "fast",
-      key: String(storage.fastKey) || "g",
+      key: storageToString(storage.fastKey, "g"),
       value: Number(storage.fastSpeed) || 1.8,
+      force: false,
+      predefined: true
+    });
+    // Remove migration from version 0.5.2
+    tc.settings.keyBindings.push({
+      action: "display",
+      key: storageToString(storage.displayKey, "v"),
+      value: 0,
       force: false,
       predefined: true
     });
@@ -134,19 +154,6 @@ chrome.storage.sync.get(tc.settings, function (storage) {
   tc.settings.startHidden = Boolean(storage.startHidden);
   tc.settings.controllerOpacity = Number(storage.controllerOpacity);
   tc.settings.blacklist = String(storage.blacklist);
-
-  // ensure that there is a "display" binding (for upgrades from versions that had it as a separate binding)
-  if (
-    tc.settings.keyBindings.filter((x) => x.action == "display").length == 0
-  ) {
-    tc.settings.keyBindings.push({
-      action: "display",
-      key: String(storage.displayKey) || "v",
-      value: 0,
-      force: false,
-      predefined: true
-    });
-  }
 
   initializeWhenReady(document);
 });
@@ -502,6 +509,7 @@ function initializeWhenReady(document) {
   }
   log("End initializeWhenReady", 5);
 }
+
 function inIframe() {
   try {
     return window.self !== window.top;
@@ -509,6 +517,7 @@ function inIframe() {
     return true;
   }
 }
+
 function getShadow(parent) {
   let result = [];
   function getChild(parent) {

--- a/inject.js
+++ b/inject.js
@@ -6,7 +6,7 @@ var tc = {
     enabled: true, // default enabled
     speeds: {}, // empty object to hold speed for each source
 
-    displayKeyCode: 86, // default: V
+    displayKey: "v", // default: V
     rememberSpeed: false, // default: false
     forceLastSavedSpeed: false, //default: false
     audioBoolean: false, // default: false
@@ -57,6 +57,7 @@ function log(message, level) {
   }
 }
 
+// TODO this has duplicated values from options.js, figure out how to only define information once
 chrome.storage.sync.get(tc.settings, function (storage) {
   tc.settings.keyBindings = storage.keyBindings; // Array
   if (storage.keyBindings.length == 0) {
@@ -64,52 +65,52 @@ chrome.storage.sync.get(tc.settings, function (storage) {
     // UPDATE
     tc.settings.keyBindings.push({
       action: "slower",
-      key: Number(storage.slowerKeyCode) || 83,
+      key: String(storage.slowerKey) || "s"
       value: Number(storage.speedStep) || 0.1,
       force: false,
       predefined: true
-    }); // default S
+    });
     tc.settings.keyBindings.push({
       action: "faster",
-      key: Number(storage.fasterKeyCode) || 68,
+      key: String(storage.fasterKey) || "d",
       value: Number(storage.speedStep) || 0.1,
       force: false,
       predefined: true
-    }); // default: D
+    });
     tc.settings.keyBindings.push({
       action: "rewind",
-      key: Number(storage.rewindKeyCode) || 90,
+      key: String(storage.rewindKey) || "z",
       value: Number(storage.rewindTime) || 10,
       force: false,
       predefined: true
-    }); // default: Z
+    });
     tc.settings.keyBindings.push({
       action: "advance",
-      key: Number(storage.advanceKeyCode) || 88,
+      key: String(storage.advanceKey) || "x",
       value: Number(storage.advanceTime) || 10,
       force: false,
       predefined: true
-    }); // default: X
+    });
     tc.settings.keyBindings.push({
       action: "reset",
-      key: Number(storage.resetKeyCode) || 82,
+      key: String(storage.resetKey) || "r",
       value: 1.0,
       force: false,
       predefined: true
-    }); // default: R
+    });
     tc.settings.keyBindings.push({
       action: "fast",
-      key: Number(storage.fastKeyCode) || 71,
+      key: String(storage.fastKey) || "g",
       value: Number(storage.fastSpeed) || 1.8,
       force: false,
       predefined: true
-    }); // default: G
+    });
     tc.settings.version = "0.5.3";
 
     chrome.storage.sync.set({
       keyBindings: tc.settings.keyBindings,
       version: tc.settings.version,
-      displayKeyCode: tc.settings.displayKeyCode,
+      displayKey: tc.settings.displayKey,
       rememberSpeed: tc.settings.rememberSpeed,
       forceLastSavedSpeed: tc.settings.forceLastSavedSpeed,
       audioBoolean: tc.settings.audioBoolean,
@@ -120,7 +121,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
     });
   }
   tc.settings.lastSpeed = Number(storage.lastSpeed);
-  tc.settings.displayKeyCode = Number(storage.displayKeyCode);
+  tc.settings.displayKey = String(storage.displayKey);
   tc.settings.rememberSpeed = Boolean(storage.rememberSpeed);
   tc.settings.forceLastSavedSpeed = Boolean(storage.forceLastSavedSpeed);
   tc.settings.audioBoolean = Boolean(storage.audioBoolean);
@@ -135,11 +136,11 @@ chrome.storage.sync.get(tc.settings, function (storage) {
   ) {
     tc.settings.keyBindings.push({
       action: "display",
-      key: Number(storage.displayKeyCode) || 86,
+      key: String(storage.displayKey) || "v",
       value: 0,
       force: false,
       predefined: true
-    }); // default V
+    });
   }
 
   initializeWhenReady(document);
@@ -556,8 +557,8 @@ function initializeNow(document) {
     doc.addEventListener(
       "keydown",
       function (event) {
-        var keyCode = event.keyCode;
-        log("Processing keydown event: " + keyCode, 6);
+        let key = event.key;
+        log("Processing keydown event: " + key, 6);
 
         // Ignore if following modifier is active.
         if (
@@ -569,7 +570,7 @@ function initializeNow(document) {
           event.getModifierState("Hyper") ||
           event.getModifierState("OS")
         ) {
-          log("Keydown event ignored due to active modifier: " + keyCode, 5);
+          log("Keydown event ignored due to active modifier: " + key, 5);
           return;
         }
 
@@ -587,7 +588,7 @@ function initializeNow(document) {
           return false;
         }
 
-        var item = tc.settings.keyBindings.find((item) => item.key === keyCode);
+        let item = tc.settings.keyBindings.find((item) => item.key === key);
         if (item) {
           runAction(item.action, item.value);
           if (item.force === "true") {

--- a/inject.js
+++ b/inject.js
@@ -1,11 +1,5 @@
 // Firefox is a bad browser, except all the rest - this import is not possible
-//import {regStrip, tcDefaults} from "./constants.js";
-const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
-const tcDefaults = { speed: 1.0, displayKey: "v", rememberSpeed: false, audioBoolean: false, startHidden: false, forceLastSavedSpeed: false, enabled: true, controllerOpacity: 0.3, keyBindings: [ { action: "display", key: "v", value: 0, force: false, predefined: true }, { action: "slower", key: "s", value: 0.1, force: false, predefined: true }, { action: "faster", key: "d", value: 0.1, force: false, predefined: true }, { action: "rewind", key: "z", value: 10, force: false, predefined: true }, { action: "advance", key: "x", value: 10, force: false, predefined: true }, { action: "reset", key: "r", value: 1, force: false, predefined: true }, { action: "fast", key: "g", value: 1.8, force: false, predefined: true } ], blacklist: `www.instagram.com
-twitter.com
-imgur.com
-teams.microsoft.com
-` };
+import {regStrip, tcDefaults} from "./constants.js";
 
 //TODO parts of this this may be able to be refactored out by using tcDefaults
 var tc = {

--- a/inject.js
+++ b/inject.js
@@ -1,7 +1,7 @@
 // Firefox is a bad browser, except all the rest - this import is not possible
 //import {regStrip, tcDefaults} from "./constants.js";
-export const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
-export const tcDefaults = { speed: 1.0, displayKey: "v", rememberSpeed: false, audioBoolean: false, startHidden: false, forceLastSavedSpeed: false, enabled: true, controllerOpacity: 0.3, keyBindings: [ { action: "display", key: "v", value: 0, force: false, predefined: true }, { action: "slower", key: "s", value: 0.1, force: false, predefined: true }, { action: "faster", key: "d", value: 0.1, force: false, predefined: true }, { action: "rewind", key: "z", value: 10, force: false, predefined: true }, { action: "advance", key: "x", value: 10, force: false, predefined: true }, { action: "reset", key: "r", value: 1, force: false, predefined: true }, { action: "fast", key: "g", value: 1.8, force: false, predefined: true } ], blacklist: `www.instagram.com
+const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
+const tcDefaults = { speed: 1.0, displayKey: "v", rememberSpeed: false, audioBoolean: false, startHidden: false, forceLastSavedSpeed: false, enabled: true, controllerOpacity: 0.3, keyBindings: [ { action: "display", key: "v", value: 0, force: false, predefined: true }, { action: "slower", key: "s", value: 0.1, force: false, predefined: true }, { action: "faster", key: "d", value: 0.1, force: false, predefined: true }, { action: "rewind", key: "z", value: 10, force: false, predefined: true }, { action: "advance", key: "x", value: 10, force: false, predefined: true }, { action: "reset", key: "r", value: 1, force: false, predefined: true }, { action: "fast", key: "g", value: 1.8, force: false, predefined: true } ], blacklist: `www.instagram.com
 twitter.com
 imgur.com
 teams.microsoft.com

--- a/inject.js
+++ b/inject.js
@@ -1,3 +1,33 @@
+//import * as constants from "./constants.js";
+// Strips out whitespace before a line, I think
+const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
+
+// The default values for each setting
+const tcDefaults = {
+    speed: 1.0, // default speed to play videos
+    displayKey: "v", // is this used?
+    rememberSpeed: false,
+    audioBoolean: false,
+    startHidden: false,
+    forceLastSavedSpeed: false,
+    enabled: true,
+    controllerOpacity: 0.3,
+    keyBindings: [
+      { action: "display", key: "v", value: 0, force: false, predefined: true },
+      { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
+      { action: "faster", key: "d", value: 0.1, force: false, predefined: true },
+      { action: "rewind", key: "z", value: 10, force: false, predefined: true },
+      { action: "advance", key: "x", value: 10, force: false, predefined: true },
+      { action: "reset", key: "r", value: 1, force: false, predefined: true },
+      { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
+    ],
+    blacklist: `www.instagram.com
+  twitter.com
+  imgur.com
+  teams.microsoft.com
+  `
+  };
+
 var tc = {
   settings: {
     lastSpeed: 1.0, // default 1x
@@ -71,8 +101,6 @@ function storageToString(stored_key, default_key) {
   }
 }
 
-// TODO this has duplicated values from options.js, figure out how to only define information once
-const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
 chrome.storage.sync.get(tc.settings, function (storage) {
   tc.settings.keyBindings = storage.keyBindings; // Array
 
@@ -80,56 +108,9 @@ chrome.storage.sync.get(tc.settings, function (storage) {
 
   // The first time the extension runs...
   if (storage.keyBindings.length == 0) {
-    tc.settings.keyBindings.push({
-      action: "slower",
-      key: storageToString(storage.slowerKey, "s"),
-      value: Number(storage.speedStep) || 0.1,
-      force: false,
-      predefined: true
-    });
-    tc.settings.keyBindings.push({
-      action: "faster",
-      key: storageToString(storage.fasterKey, "d"),
-      value: Number(storage.speedStep) || 0.1,
-      force: false,
-      predefined: true
-    });
-    tc.settings.keyBindings.push({
-      action: "rewind",
-      key: storageToString(storage.rewindKey, "z"),
-      value: Number(storage.rewindTime) || 10,
-      force: false,
-      predefined: true
-    });
-    tc.settings.keyBindings.push({
-      action: "advance",
-      key: storageToString(storage.advanceKey, "x"),
-      value: Number(storage.advanceTime) || 10,
-      force: false,
-      predefined: true
-    });
-    tc.settings.keyBindings.push({
-      action: "reset",
-      key: storageToString(storage.resetKey, "r"),
-      value: 1.0,
-      force: false,
-      predefined: true
-    });
-    tc.settings.keyBindings.push({
-      action: "fast",
-      key: storageToString(storage.fastKey, "g"),
-      value: Number(storage.fastSpeed) || 1.8,
-      force: false,
-      predefined: true
-    });
-    // Remove migration from version 0.5.2
-    tc.settings.keyBindings.push({
-      action: "display",
-      key: storageToString(storage.displayKey, "v"),
-      value: 0,
-      force: false,
-      predefined: true
-    });
+    tc.settings.keyBindings = tcDefaults.keyBindings;
+
+    // Removed migration from version 0.5.2 to 0.5.3
     tc.settings.version = "0.5.3";
 
     chrome.storage.sync.set({

--- a/inject.js
+++ b/inject.js
@@ -38,6 +38,7 @@ var tc = {
 */
 function log(message, level) {
   verbosity = tc.settings.logLevel;
+	verbosity = 6; //TODO
   if (typeof level === "undefined") {
     level = tc.settings.defaultLogLevel;
   }

--- a/inject.js
+++ b/inject.js
@@ -1,11 +1,30 @@
 // Firefox is a bad browser, except all the rest - this import is not possible
 //import {regStrip, tcDefaults} from "./constants.js";
 const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
-const tcDefaults = { speed: 1.0, displayKey: "v", rememberSpeed: false, audioBoolean: false, startHidden: false, forceLastSavedSpeed: false, enabled: true, controllerOpacity: 0.3, keyBindings: [ { action: "display", key: "v", value: 0, force: false, predefined: true }, { action: "slower", key: "s", value: 0.1, force: false, predefined: true }, { action: "faster", key: "d", value: 0.1, force: false, predefined: true }, { action: "rewind", key: "z", value: 10, force: false, predefined: true }, { action: "advance", key: "x", value: 10, force: false, predefined: true }, { action: "reset", key: "r", value: 1, force: false, predefined: true }, { action: "fast", key: "g", value: 1.8, force: false, predefined: true } ], blacklist: `www.instagram.com
+const tcDefaults = {
+  speed: 1.0,
+  displayKey: "v",
+  rememberSpeed: false,
+  audioBoolean: false,
+  startHidden: false,
+  forceLastSavedSpeed: false,
+  enabled: true,
+  controllerOpacity: 0.3,
+  keyBindings: [
+    { action: "display", key: "v", value: 0, force: false, predefined: true },
+    { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
+    { action: "faster", key: "d", value: 0.1, force: false, predefined: true },
+    { action: "rewind", key: "z", value: 10, force: false, predefined: true },
+    { action: "advance", key: "x", value: 10, force: false, predefined: true },
+    { action: "reset", key: "r", value: 1, force: false, predefined: true },
+    { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
+  ],
+  blacklist: `www.instagram.com
 twitter.com
 imgur.com
 teams.microsoft.com
-` };
+`
+};
 
 //TODO parts of this this may be able to be refactored out by using tcDefaults
 var tc = {

--- a/inject.js
+++ b/inject.js
@@ -1,34 +1,13 @@
 // Firefox is a bad browser, except all the rest - this import is not possible
 //import {regStrip, tcDefaults} from "./constants.js";
-// Strips out whitespace before a line, I think
 const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
+const tcDefaults = { speed: 1.0, displayKey: "v", rememberSpeed: false, audioBoolean: false, startHidden: false, forceLastSavedSpeed: false, enabled: true, controllerOpacity: 0.3, keyBindings: [ { action: "display", key: "v", value: 0, force: false, predefined: true }, { action: "slower", key: "s", value: 0.1, force: false, predefined: true }, { action: "faster", key: "d", value: 0.1, force: false, predefined: true }, { action: "rewind", key: "z", value: 10, force: false, predefined: true }, { action: "advance", key: "x", value: 10, force: false, predefined: true }, { action: "reset", key: "r", value: 1, force: false, predefined: true }, { action: "fast", key: "g", value: 1.8, force: false, predefined: true } ], blacklist: `www.instagram.com
+twitter.com
+imgur.com
+teams.microsoft.com
+` };
 
-// The default values for each setting
-const tcDefaults = {
-    speed: 1.0, // default speed to play videos
-    displayKey: "v", // is this used?
-    rememberSpeed: false,
-    audioBoolean: false,
-    startHidden: false,
-    forceLastSavedSpeed: false,
-    enabled: true,
-    controllerOpacity: 0.3,
-    keyBindings: [
-      { action: "display", key: "v", value: 0, force: false, predefined: true },
-      { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
-      { action: "faster", key: "d", value: 0.1, force: false, predefined: true },
-      { action: "rewind", key: "z", value: 10, force: false, predefined: true },
-      { action: "advance", key: "x", value: 10, force: false, predefined: true },
-      { action: "reset", key: "r", value: 1, force: false, predefined: true },
-      { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
-    ],
-    blacklist: `www.instagram.com
-  twitter.com
-  imgur.com
-  teams.microsoft.com
-  `
-  };
-
+//TODO parts of this this may be able to be refactored out by using tcDefaults
 var tc = {
   settings: {
     lastSpeed: 1.0, // default 1x
@@ -93,7 +72,7 @@ function log(message, level) {
   }
 }
 
-// Needed because you cannot || with "undefined". Only used in the next function
+// Needed because you cannot || with "undefined". Only used in the next lambda function
 function storageToString(stored_key, default_key) {
   if (stored_key) {
     return String(stored_key);
@@ -111,7 +90,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
   if (storage.keyBindings.length == 0) {
     tc.settings.keyBindings = tcDefaults.keyBindings;
 
-    // Removed migration from version 0.5.2 to 0.5.3
+    //TODO what does this do?
     tc.settings.version = "0.5.3";
 
     chrome.storage.sync.set({

--- a/inject.js
+++ b/inject.js
@@ -19,7 +19,8 @@ const tcDefaults = {
     { action: "reset", key: "r", value: 1, force: false, predefined: true },
     { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
   ],
-  blacklist: `www.instagram.com
+  blacklist: `\
+www.instagram.com
 twitter.com
 imgur.com
 teams.microsoft.com
@@ -40,7 +41,7 @@ var tc = {
     startHidden: false,
     controllerOpacity: 0.3,
     keyBindings: [],
-    blacklist: `
+    blacklist: `\
 www.instagram.com
 twitter.com
 imgur.com

--- a/inject.js
+++ b/inject.js
@@ -337,14 +337,15 @@ function defineVideoController() {
     var fragment = document.createDocumentFragment();
     fragment.appendChild(wrapper);
 
-    switch (location.hostname) {
-      case "www.amazon.com":
-      case "www.reddit.com":
+    // This seemed strange to me at first, but switching on true here allows matching regexes
+    switch (true) {
+      case location.hostname == "www.amazon.com":
+      case /\.*.reddit.com/.test(location.hostname):
       case /hbogo\./.test(location.hostname):
         // insert before parent to bypass overlay
         this.parent.parentElement.insertBefore(fragment, this.parent);
         break;
-      case "www.facebook.com":
+      case location.hostname == "www.facebook.com":
         // this is a monstrosity but new FB design does not have *any*
         // semantic handles for us to traverse the tree, and deep nesting
         // that we need to bubble up from to get controller to stack correctly
@@ -353,7 +354,7 @@ function defineVideoController() {
             .parentElement.parentElement.parentElement;
         p.insertBefore(fragment, p.firstChild);
         break;
-      case "tv.apple.com":
+      case location.hostname == "tv.apple.com":
         // insert after parent for correct stacking context
         this.parent.getRootNode().querySelector(".scrim").prepend(fragment);
       default:

--- a/options.html
+++ b/options.html
@@ -3,7 +3,7 @@
   <head>
     <title>Video Speed Controller: Options</title>
     <link rel="stylesheet" href="options.css" />
-    <script src="options.js"></script>
+    <script type="module" src="options.js"></script>
   </head>
   <body>
     <header>

--- a/options.html
+++ b/options.html
@@ -161,6 +161,10 @@
         <input id="controllerOpacity" type="text" value="" />
       </div>
       <div class="row">
+        <label for="controllerSize">Controller opacity</label>
+        <input id="controllerSize" type="text" value="" />
+      </div>
+      <div class="row">
         <label for="blacklist"
           >Sites on which extension is disabled<br />
           (one per line)<br />

--- a/options.js
+++ b/options.js
@@ -2,7 +2,7 @@ var regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
 
 // The default values for each setting
 var tcDefaults = {
-  speed: 1.0, // default speed
+  speed: 1.0, // default speed to play videos
   displayKey: "v", // is this used?
   rememberSpeed: false,
   audioBoolean: false,

--- a/options.js
+++ b/options.js
@@ -20,10 +20,10 @@ var tcDefaults = {
     { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
   ],
   blacklist: `www.instagram.com
-    twitter.com
-    imgur.com
-    teams.microsoft.com
-  `.replace(regStrip, "")
+twitter.com
+imgur.com
+teams.microsoft.com
+`
 };
 
 var keyBindings = [];
@@ -136,7 +136,7 @@ function validate() {
         } catch (err) {
           status.textContent =
             "Error: Invalid blacklist regex: " + match + ". Unable to save";
-            return false;
+          return false;
         }
       }
     });
@@ -154,7 +154,9 @@ function save_options() {
   ); // Remove added shortcuts
 
   let rememberSpeed = document.getElementById("rememberSpeed").checked;
-  let forceLastSavedSpeed = document.getElementById("forceLastSavedSpeed").checked;
+  let forceLastSavedSpeed = document.getElementById(
+    "forceLastSavedSpeed"
+  ).checked;
   let audioBoolean = document.getElementById("audioBoolean").checked;
   let enabled = document.getElementById("enabled").checked;
   let startHidden = document.getElementById("startHidden").checked;
@@ -200,7 +202,8 @@ function save_options() {
 function restore_options() {
   chrome.storage.sync.get(tcDefaults, function (storage) {
     document.getElementById("rememberSpeed").checked = storage.rememberSpeed;
-    document.getElementById("forceLastSavedSpeed").checked = storage.forceLastSavedSpeed;
+    document.getElementById("forceLastSavedSpeed").checked =
+      storage.forceLastSavedSpeed;
     document.getElementById("audioBoolean").checked = storage.audioBoolean;
     document.getElementById("enabled").checked = storage.enabled;
     document.getElementById("startHidden").checked = storage.startHidden;
@@ -217,7 +220,7 @@ function restore_options() {
         predefined: true
       });
     }
-
+    
     for (let i in storage.keyBindings) {
       var item = storage.keyBindings[i];
       if (item.predefined) {
@@ -294,7 +297,10 @@ document.addEventListener("DOMContentLoaded", function () {
     .addEventListener("click", show_experimental);
 
   function eventCaller(event, className, funcName) {
-    if (!event.target.classList || !event.target.classList.contains(className)) {
+    if (
+      !event.target.classList ||
+      !event.target.classList.contains(className)
+    ) {
       return;
     }
     funcName(event);
@@ -385,7 +391,7 @@ const keyCodeAliases = {
   220: "\\",
   221: "]",
   222: "'",
-  59:  ";",
-  61:  "+",
-  173: "-",
+  59: ";",
+  61: "+",
+  173: "-"
 };

--- a/options.js
+++ b/options.js
@@ -1,5 +1,3 @@
-var regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
-
 // The default values for each setting
 var tcDefaults = {
   speed: 1.0, // default speed to play videos
@@ -125,6 +123,7 @@ function createKeyBindings(item) {
 // Validates settings before saving
 function validate() {
   let status = document.getElementById("status");
+  const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
   document
     .getElementById("blacklist")
     .value.split("\n")
@@ -185,7 +184,7 @@ function save_options() {
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
       keyBindings: keyBindings,
-      blacklist: blacklist.replace(regStrip, "")
+      blacklist: blacklist
     },
     function () {
       // Update status to let user know options were saved.

--- a/options.js
+++ b/options.js
@@ -191,7 +191,7 @@ function restore_options() {
     document.getElementById("controllerOpacity").value =
       storage.controllerOpacity;
     document.getElementById("blacklist").value = storage.blacklist;
-    
+
     for (let i in storage.keyBindings) {
       var item = storage.keyBindings[i];
       if (item.predefined) {

--- a/options.js
+++ b/options.js
@@ -27,67 +27,14 @@ var tcDefaults = {
 
 var keyBindings = [];
 
-var keyCodeAliases = {
-  0: "null",
-  null: "null",
-  undefined: "null",
-  32: "Space",
-  37: "Left",
-  38: "Up",
-  39: "Right",
-  40: "Down",
-  96: "Num 0",
-  97: "Num 1",
-  98: "Num 2",
-  99: "Num 3",
-  100: "Num 4",
-  101: "Num 5",
-  102: "Num 6",
-  103: "Num 7",
-  104: "Num 8",
-  105: "Num 9",
-  106: "Num *",
-  107: "Num +",
-  109: "Num -",
-  110: "Num .",
-  111: "Num /",
-  112: "F1",
-  113: "F2",
-  114: "F3",
-  115: "F4",
-  116: "F5",
-  117: "F6",
-  118: "F7",
-  119: "F8",
-  120: "F9",
-  121: "F10",
-  122: "F11",
-  123: "F12",
-  186: ";",
-  188: "<",
-  189: "-",
-  187: "+",
-  190: ">",
-  191: "/",
-  192: "~",
-  219: "[",
-  220: "\\",
-  221: "]",
-  222: "'",
-  59:  ";",
-  61:  "+",
-  173: "-",
-};
-
 function recordKeyPress(e) {
   if (
     (e.keyCode >= 48 && e.keyCode <= 57) || // Numbers 0-9
     (e.keyCode >= 65 && e.keyCode <= 90) || // Letters A-Z
     keyCodeAliases[e.keyCode] // Other character keys
   ) {
-    e.target.value =
-      keyCodeAliases[e.keyCode] || String.fromCharCode(e.keyCode);
-    e.target.keyCode = e.keyCode;
+    e.target.value = getKeyCodeValue(e);
+    e.target.key = e.key;
 
     e.preventDefault();
     e.stopPropagation();
@@ -97,12 +44,12 @@ function recordKeyPress(e) {
   } else if (e.keyCode === 27) {
     // When esc clicked, clear input
     e.target.value = "null";
-    e.target.keyCode = null;
+    e.target.key = null;
   }
 }
 
 function inputFilterNumbersOnly(e) {
-  var char = String.fromCharCode(e.keyCode);
+  var char = e.key;
   if (!/[\d\.]$/.test(char) || !/^\d+(\.\d*)?$/.test(e.target.value + char)) {
     e.preventDefault();
     e.stopPropagation();
@@ -114,8 +61,7 @@ function inputFocus(e) {
 }
 
 function inputBlur(e) {
-  e.target.value =
-    keyCodeAliases[e.target.keyCode] || String.fromCharCode(e.target.keyCode);
+  e.target.value = getKeyCodeValue(e);
 }
 
 function updateShortcutInputText(inputId, keyCode) {
@@ -387,3 +333,62 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 });
+
+function getKeyCodeValue(e) {
+  if (e.keyCode >= 65 && e.keyCode <= 90) { // Letters A-Z may be capital or lowercase
+    return e.key;
+  }
+  return keyCodeAliases[e.keyCode] || String.fromCharCode(e.keyCode);
+}
+
+const keyCodeAliases = {
+  0: "null",
+  null: "null",
+  undefined: "null",
+  32: "Space",
+  37: "Left",
+  38: "Up",
+  39: "Right",
+  40: "Down",
+  96: "Num 0",
+  97: "Num 1",
+  98: "Num 2",
+  99: "Num 3",
+  100: "Num 4",
+  101: "Num 5",
+  102: "Num 6",
+  103: "Num 7",
+  104: "Num 8",
+  105: "Num 9",
+  106: "Num *",
+  107: "Num +",
+  109: "Num -",
+  110: "Num .",
+  111: "Num /",
+  112: "F1",
+  113: "F2",
+  114: "F3",
+  115: "F4",
+  116: "F5",
+  117: "F6",
+  118: "F7",
+  119: "F8",
+  120: "F9",
+  121: "F10",
+  122: "F11",
+  123: "F12",
+  186: ";",
+  188: "<",
+  189: "-",
+  187: "+",
+  190: ">",
+  191: "/",
+  192: "~",
+  219: "[",
+  220: "\\",
+  221: "]",
+  222: "'",
+  59:  ";",
+  61:  "+",
+  173: "-",
+};

--- a/options.js
+++ b/options.js
@@ -1,4 +1,5 @@
-//import * as constants from "./constants.js";
+// Firefox is a bad browser, except for all the rest - this import is not possible.
+//import {regStrip, tcDefaults} as constants from "./constants.js";
 // Strips out whitespace before a line, I think
 const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
 

--- a/options.js
+++ b/options.js
@@ -1,14 +1,15 @@
 var regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
 
+// The default values for each setting
 var tcDefaults = {
-  speed: 1.0, // default:
-  displayKey: "v", // default: V
-  rememberSpeed: false, // default: false
-  audioBoolean: false, // default: false
-  startHidden: false, // default: false
-  forceLastSavedSpeed: false, //default: false
-  enabled: true, // default enabled
-  controllerOpacity: 0.3, // default: 0.3
+  speed: 1.0, // default speed
+  displayKey: "v", // is this used?
+  rememberSpeed: false,
+  audioBoolean: false,
+  startHidden: false,
+  forceLastSavedSpeed: false,
+  enabled: true,
+  controllerOpacity: 0.3,
   keyBindings: [
     { action: "display", key: "v", value: 0, force: false, predefined: true },
     { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
@@ -33,7 +34,7 @@ function recordKeyPress(e) {
     (e.keyCode >= 65 && e.keyCode <= 90) || // Letters A-Z
     keyCodeAliases[e.keyCode] // Other character keys
   ) {
-    e.target.value = getKeyCodeValue(e);
+    e.target.value = getKeyCodeName(e);
     e.target.key = e.key;
     e.target.keyCode = e.keyCode;
 
@@ -51,8 +52,8 @@ function recordKeyPress(e) {
 }
 
 function inputFilterNumbersOnly(e) {
-  var char = e.key;
-  if (!/[\d\.]$/.test(char) || !/^\d+(\.\d*)?$/.test(e.target.value + char)) {
+  var chr = e.key;
+  if (!/[\d\.]$/.test(chr) || !/^\d+(\.\d*)?$/.test(e.target.value + chr)) {
     e.preventDefault();
     e.stopPropagation();
   }
@@ -63,12 +64,12 @@ function inputFocus(e) {
 }
 
 function inputBlur(e) {
-  e.target.value = getKeyCodeValue(e);
+  e.target.value = getKeyCodeName(e);
 }
 
-function updateCustomShortcutInputText(inputItem, keyCode) {
-  inputItem.value = keyCodeAliases[keyCode] || String.fromCharCode(keyCode);
-  inputItem.keyCode = keyCode;
+function updateCustomShortcutInputText(inputItem, key) {
+  inputItem.value = key;
+  inputItem.key = key;
 }
 
 // List of custom actions for which there is no numeric argument
@@ -166,12 +167,12 @@ function save_options() {
     "fastSpeed",
     "rewindTime",
     "advanceTime",
-    "resetKeyCode",
-    "slowerKeyCode",
-    "fasterKeyCode",
-    "rewindKeyCode",
-    "advanceKeyCode",
-    "fastKeyCode"
+    "resetKey",
+    "slowerKey",
+    "fasterKey",
+    "rewindKey",
+    "advanceKey",
+    "fastKey"
   ]);
   chrome.storage.sync.set(
     {
@@ -328,13 +329,15 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 });
 
-function getKeyCodeValue(e) {
-  if (e.keyCode >= 65 && e.keyCode <= 90) { // Letters A-Z may be capital or lowercase
+function getKeyCodeName(e) {
+  // Letters A-Z may be capital or lowercase
+  if (e.keyCode >= 65 && e.keyCode <= 90) {
     return e.key;
   }
   return keyCodeAliases[e.keyCode] || String.fromCharCode(e.keyCode);
 }
 
+// May be a prettier name than e.key
 const keyCodeAliases = {
   0: "null",
   null: "null",

--- a/options.js
+++ b/options.js
@@ -136,6 +136,7 @@ function save_options() {
   let enabled = document.getElementById("enabled").checked;
   let startHidden = document.getElementById("startHidden").checked;
   let controllerOpacity = document.getElementById("controllerOpacity").value;
+  let controllerSize = document.getElementById("controllerSize").value;
   let blacklist = document.getElementById("blacklist").value;
 
   chrome.storage.sync.remove([
@@ -159,6 +160,7 @@ function save_options() {
       enabled: enabled,
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
+      controllerSize: controllerSize,
       keyBindings: keyBindings,
       blacklist: blacklist
     },
@@ -184,6 +186,8 @@ function restore_options() {
     document.getElementById("startHidden").checked = storage.startHidden;
     document.getElementById("controllerOpacity").value =
       storage.controllerOpacity;
+    document.getElementById("controllerSize").value =
+      storage.controllerSize;
     document.getElementById("blacklist").value = storage.blacklist;
 
     for (let i in storage.keyBindings) {

--- a/options.js
+++ b/options.js
@@ -1,11 +1,5 @@
 // Firefox is a bad browser, except for all the rest - this import is not possible.
-//import {regStrip, tcDefaults} as constants from "./constants.js";
-const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
-const tcDefaults = { speed: 1.0, displayKey: "v", rememberSpeed: false, audioBoolean: false, startHidden: false, forceLastSavedSpeed: false, enabled: true, controllerOpacity: 0.3, keyBindings: [ { action: "display", key: "v", value: 0, force: false, predefined: true }, { action: "slower", key: "s", value: 0.1, force: false, predefined: true }, { action: "faster", key: "d", value: 0.1, force: false, predefined: true }, { action: "rewind", key: "z", value: 10, force: false, predefined: true }, { action: "advance", key: "x", value: 10, force: false, predefined: true }, { action: "reset", key: "r", value: 1, force: false, predefined: true }, { action: "fast", key: "g", value: 1.8, force: false, predefined: true } ], blacklist: `www.instagram.com
-twitter.com
-imgur.com
-teams.microsoft.com
-` };
+import {regStrip, tcDefaults} as constants from "./constants.js";
 
 var keyBindings = [];
 

--- a/options.js
+++ b/options.js
@@ -1,5 +1,5 @@
 // Firefox is a bad browser, except for all the rest - this import is not possible.
-import {regStrip, tcDefaults} as constants from "./constants.js";
+import {regStrip, tcDefaults} from "./constants.js";
 
 var keyBindings = [];
 

--- a/options.js
+++ b/options.js
@@ -1,33 +1,11 @@
 // Firefox is a bad browser, except for all the rest - this import is not possible.
 //import {regStrip, tcDefaults} as constants from "./constants.js";
-// Strips out whitespace before a line, I think
 const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
-
-// The default values for each setting
-const tcDefaults = {
-    speed: 1.0, // default speed to play videos
-    displayKey: "v", // is this used?
-    rememberSpeed: false,
-    audioBoolean: false,
-    startHidden: false,
-    forceLastSavedSpeed: false,
-    enabled: true,
-    controllerOpacity: 0.3,
-    keyBindings: [
-      { action: "display", key: "v", value: 0, force: false, predefined: true },
-      { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
-      { action: "faster", key: "d", value: 0.1, force: false, predefined: true },
-      { action: "rewind", key: "z", value: 10, force: false, predefined: true },
-      { action: "advance", key: "x", value: 10, force: false, predefined: true },
-      { action: "reset", key: "r", value: 1, force: false, predefined: true },
-      { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
-    ],
-    blacklist: `www.instagram.com
-  twitter.com
-  imgur.com
-  teams.microsoft.com
-  `
-  };
+const tcDefaults = { speed: 1.0, displayKey: "v", rememberSpeed: false, audioBoolean: false, startHidden: false, forceLastSavedSpeed: false, enabled: true, controllerOpacity: 0.3, keyBindings: [ { action: "display", key: "v", value: 0, force: false, predefined: true }, { action: "slower", key: "s", value: 0.1, force: false, predefined: true }, { action: "faster", key: "d", value: 0.1, force: false, predefined: true }, { action: "rewind", key: "z", value: 10, force: false, predefined: true }, { action: "advance", key: "x", value: 10, force: false, predefined: true }, { action: "reset", key: "r", value: 1, force: false, predefined: true }, { action: "fast", key: "g", value: 1.8, force: false, predefined: true } ], blacklist: `www.instagram.com
+twitter.com
+imgur.com
+teams.microsoft.com
+` };
 
 var keyBindings = [];
 

--- a/options.js
+++ b/options.js
@@ -1,5 +1,5 @@
 // Firefox is a bad browser, except for all the rest - this import is not possible.
-import {regStrip, tcDefaults} from "./constants.js";
+import { regStrip, tcDefaults } from "./constants.js";
 
 var keyBindings = [];
 

--- a/options.js
+++ b/options.js
@@ -1,28 +1,32 @@
+//import * as constants from "./constants.js";
+// Strips out whitespace before a line, I think
+const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
+
 // The default values for each setting
-var tcDefaults = {
-  speed: 1.0, // default speed to play videos
-  displayKey: "v", // is this used?
-  rememberSpeed: false,
-  audioBoolean: false,
-  startHidden: false,
-  forceLastSavedSpeed: false,
-  enabled: true,
-  controllerOpacity: 0.3,
-  keyBindings: [
-    { action: "display", key: "v", value: 0, force: false, predefined: true },
-    { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
-    { action: "faster", key: "d", value: 0.1, force: false, predefined: true },
-    { action: "rewind", key: "z", value: 10, force: false, predefined: true },
-    { action: "advance", key: "x", value: 10, force: false, predefined: true },
-    { action: "reset", key: "r", value: 1, force: false, predefined: true },
-    { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
-  ],
-  blacklist: `www.instagram.com
-twitter.com
-imgur.com
-teams.microsoft.com
-`
-};
+const tcDefaults = {
+    speed: 1.0, // default speed to play videos
+    displayKey: "v", // is this used?
+    rememberSpeed: false,
+    audioBoolean: false,
+    startHidden: false,
+    forceLastSavedSpeed: false,
+    enabled: true,
+    controllerOpacity: 0.3,
+    keyBindings: [
+      { action: "display", key: "v", value: 0, force: false, predefined: true },
+      { action: "slower", key: "s", value: 0.1, force: false, predefined: true },
+      { action: "faster", key: "d", value: 0.1, force: false, predefined: true },
+      { action: "rewind", key: "z", value: 10, force: false, predefined: true },
+      { action: "advance", key: "x", value: 10, force: false, predefined: true },
+      { action: "reset", key: "r", value: 1, force: false, predefined: true },
+      { action: "fast", key: "g", value: 1.8, force: false, predefined: true }
+    ],
+    blacklist: `www.instagram.com
+  twitter.com
+  imgur.com
+  teams.microsoft.com
+  `
+  };
 
 var keyBindings = [];
 
@@ -123,7 +127,6 @@ function createKeyBindings(item) {
 // Validates settings before saving
 function validate() {
   let status = document.getElementById("status");
-  const regStrip = /^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
   document
     .getElementById("blacklist")
     .value.split("\n")
@@ -209,16 +212,6 @@ function restore_options() {
     document.getElementById("controllerOpacity").value =
       storage.controllerOpacity;
     document.getElementById("blacklist").value = storage.blacklist;
-
-    // ensure that there is a "display" binding for upgrades from versions that had it as a separate binding
-    if (storage.keyBindings.filter((x) => x.action == "display").length == 0) {
-      storage.keyBindings.push({
-        action: "display",
-        value: 0,
-        force: false,
-        predefined: true
-      });
-    }
     
     for (let i in storage.keyBindings) {
       var item = storage.keyBindings[i];

--- a/shadow.css
+++ b/shadow.css
@@ -1,7 +1,6 @@
 * {
   line-height: 1.9em;
   font-family: sans-serif;
-  font-size: 13px;
 }
 
 :host(:hover) #controls {
@@ -16,9 +15,9 @@
   background: black;
   color: white;
 
-  border-radius: 5px;
-  padding: 5px;
-  margin: 10px 10px 10px 15px;
+  border-radius: 0.4em;
+  padding: 0.4em;
+  margin: 4px;
 
   cursor: default;
   z-index: 9999999;
@@ -61,13 +60,11 @@ button {
   color: black;
   background: white;
   font-weight: bold;
-  border-radius: 5px;
-  padding: 3px 6px 3px 6px;
-  font-size: 14px;
-  line-height: 14px;
+  border-radius: 0.4em;
+  padding: 0.4em 0.55em 0.4em 0.55em;
+  line-height: 0.5em;
   border: 1px solid white;
   font-family: "Lucida Console", Monaco, monospace;
-  margin-bottom: 2px;
 }
 
 button:focus {


### PR DESCRIPTION
This refactors a lot of input code to resolve #167 (shortcuts can be set to either uppercase or lowercase). The way it does so is by mostly ignoring the `keyCode` attribute of an input event and instead using the string `key` which contains more information and in a more human-readable way. Unfortunately, this currently means it breaks any preconfigured options a user has set and users will need to reconfigure it. Assuming this is unacceptable (I assume it is) I can add in a migration strategy; but I need to know how best that done.

I also removed the old 5.3.0 settings conversion code because its been here long enough I think. In doing so, I was able to simplify some logic. Additionally, `vine.co` does not really exist anymore so disabling the extension there by default is unneeded I think.

I need testing for numpad keys to see if they still work the same. I wrote this all on a laptop without them.

There are several TODOs marked around the code where I wasn't sure what was going on and need review to tell me if my comments are correct or not.

The version is not bumped, please tell me how to change it. This could be a bump to `0.7.0.0` or something, to signify it is a breaking change and add no migration. Or it could need to be updated to have a migration path, and become `0.6.4.0`. Or maybe the project tracks upstream versions directly and only `manifest-version` should be bumped. I'm not sure.

EDIT: now adds the feature suggested in #119 also