### PR TITLE
Fix reddit weirdness

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -343,7 +343,6 @@ function defineVideoController() {
     var fragment = document.createDocumentFragment();
     fragment.appendChild(wrapper);
 
-    console.log(this.parent);
     let p = this.parent;
     switch (true) {
       case location.hostname == "www.amazon.com":

--- a/inject.js
+++ b/inject.js
@@ -343,30 +343,34 @@ function defineVideoController() {
     var fragment = document.createDocumentFragment();
     fragment.appendChild(wrapper);
 
+    console.log(this.parent);
+    let p = this.parent;
     switch (true) {
       case location.hostname == "www.amazon.com":
       case /\.*.reddit.com/.test(location.hostname):
       case /hbogo\./.test(location.hostname):
         // insert before parent to bypass overlay
-        this.parent.parentElement.insertBefore(fragment, this.parent);
+        p = p.parentElement;
         break;
       case location.hostname == "www.facebook.com":
         // this is a monstrosity but new FB design does not have *any*
         // semantic handles for us to traverse the tree, and deep nesting
         // that we need to bubble up from to get controller to stack correctly
-        let p = this.parent.parentElement.parentElement.parentElement
+        p = p.parentElement.parentElement.parentElement
           .parentElement.parentElement.parentElement.parentElement;
-        p.insertBefore(fragment, p.firstChild);
+        break;
+      case location.hostname == "www.netflix.com":
+        p = p.parentElement.parentElement.parentElement;
         break;
       case location.hostname == "tv.apple.com":
         // insert after parent for correct stacking context
-        this.parent.getRootNode().querySelector(".scrim").prepend(fragment);
+        p.getRootNode().querySelector(".scrim").prepend(fragment);
       default:
         // Note: when triggered via a MutationRecord, it's possible that the
         // target is not the immediate parent. This appends the controller as
         // the first element of the target, which may not be the parent.
-        this.parent.insertBefore(fragment, this.parent.firstChild);
     }
+    p.insertBefore(fragment,p.firstChild);
     return wrapper;
   };
 }

--- a/inject.js
+++ b/inject.js
@@ -345,23 +345,23 @@ function defineVideoController() {
 
     let p = this.parent;
     switch (true) {
-      case location.hostname == "www.amazon.com":
+      case location.hostname === "www.amazon.com":
       case /\.*.reddit.com/.test(location.hostname):
       case /hbogo\./.test(location.hostname):
         // insert before parent to bypass overlay
         p = p.parentElement;
         break;
-      case location.hostname == "www.facebook.com":
+      case location.hostname === "www.facebook.com":
         // this is a monstrosity but new FB design does not have *any*
         // semantic handles for us to traverse the tree, and deep nesting
         // that we need to bubble up from to get controller to stack correctly
         p = p.parentElement.parentElement.parentElement
           .parentElement.parentElement.parentElement.parentElement;
         break;
-      case location.hostname == "www.netflix.com":
+      case location.hostname === "www.netflix.com":
         p = p.parentElement.parentElement.parentElement;
         break;
-      case location.hostname == "tv.apple.com":
+      case location.hostname === "tv.apple.com":
         // insert after parent for correct stacking context
         p.getRootNode().querySelector(".scrim").prepend(fragment);
       default:

--- a/inject.js
+++ b/inject.js
@@ -273,8 +273,7 @@ function defineVideoController() {
     log("initializeControls Begin", 5);
     const document = this.video.ownerDocument;
     const speed = this.video.playbackRate.toFixed(2);
-    var top = Math.max(this.video.offsetTop, 0) + "px",
-      left = Math.max(this.video.offsetLeft, 0) + "px";
+    const top = "0px", left = "0px";
 
     log("Speed variable set to: " + speed, 5);
 
@@ -346,7 +345,7 @@ function defineVideoController() {
 
     switch (true) {
       case location.hostname == "www.amazon.com":
-      case location.hostname == "www.reddit.com":
+      case /\.*.reddit.com/.test(location.hostname):
       case /hbogo\./.test(location.hostname):
         // insert before parent to bypass overlay
         this.parent.parentElement.insertBefore(fragment, this.parent);


### PR DESCRIPTION
Resolves #166.

Makes it so any reddit URL will apply the correct reddit rule to be able to drag around the controller, rather than only `www.reddit.com`.

Hardcodes `top` and `left` to `"0px"` instead of `var top = Math.max(this.video.offsetTop, 0) + "px"`. I cannot seem to find an example where there is a difference, is there one? If so, would it be better to switch on the website name and set `top` and `left` based on that, since it seems to me that it is more likely the old behavior will produce unexpected results than correct ones?

EDIT: resolves #158 too now