### PR TITLE
Changed the blacklist to an allowlist - Resolves #196

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -13,12 +13,8 @@ var tc = {
     startHidden: false, // default: false
     controllerOpacity: 0.3, // default: 0.3
     keyBindings: [],
-    blacklist: `\
-      www.instagram.com
-      twitter.com
-      vine.co
-      imgur.com
-      teams.microsoft.com
+    allowList: `\
+      youtube.com
     `.replace(regStrip, ""),
     defaultLogLevel: 4,
     logLevel: 3
@@ -116,7 +112,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
       startHidden: tc.settings.startHidden,
       enabled: tc.settings.enabled,
       controllerOpacity: tc.settings.controllerOpacity,
-      blacklist: tc.settings.blacklist.replace(regStrip, "")
+      allowList: tc.settings.allowList.replace(regStrip, "")
     });
   }
   tc.settings.lastSpeed = Number(storage.lastSpeed);
@@ -127,7 +123,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
   tc.settings.enabled = Boolean(storage.enabled);
   tc.settings.startHidden = Boolean(storage.startHidden);
   tc.settings.controllerOpacity = Number(storage.controllerOpacity);
-  tc.settings.blacklist = String(storage.blacklist);
+  tc.settings.allowList = String(storage.allowList);
 
   // ensure that there is a "display" binding (for upgrades from versions that had it as a separate binding)
   if (
@@ -377,9 +373,9 @@ function escapeStringRegExp(str) {
   return str.replace(matchOperatorsRe, "\\$&");
 }
 
-function isBlacklisted() {
-  blacklisted = false;
-  tc.settings.blacklist.split("\n").forEach((match) => {
+function isAllowListed() {
+  allowListed = false;
+  tc.settings.allowList.split("\n").forEach((match) => {
     match = match.replace(regStrip, "");
     if (match.length == 0) {
       return;
@@ -396,11 +392,11 @@ function isBlacklisted() {
     }
 
     if (regexp.test(location.href)) {
-      blacklisted = true;
+      allowListed = true;
       return;
     }
   });
-  return blacklisted;
+  return allowListed;
 }
 
 var coolDown = false;
@@ -478,7 +474,7 @@ function setupListener() {
 
 function initializeWhenReady(document) {
   log("Begin initializeWhenReady", 5);
-  if (isBlacklisted()) {
+  if (!isAllowListed()) {
     return;
   }
   window.addEventListener('load', () => {

--- a/options.html
+++ b/options.html
@@ -161,8 +161,8 @@
         <input id="controllerOpacity" type="text" value="" />
       </div>
       <div class="row">
-        <label for="blacklist"
-          >Sites on which extension is disabled<br />
+        <label for="allowList"
+          >Sites on which extension is enabled<br />
           (one per line)<br />
           <br />
           <em>
@@ -171,7 +171,7 @@
             ie: /(.+)youtube\.com(\/*)$/gi
           </em>
         </label>
-        <textarea id="blacklist" rows="10" cols="50"></textarea>
+        <textarea id="allowList" rows="10" cols="50"></textarea>
       </div>
     </section>
 

--- a/options.js
+++ b/options.js
@@ -18,10 +18,7 @@ var tcDefaults = {
     { action: "reset", key: 82, value: 1, force: false, predefined: true }, // R
     { action: "fast", key: 71, value: 1.8, force: false, predefined: true } // G
   ],
-  blacklist: `www.instagram.com
-    twitter.com
-    imgur.com
-    teams.microsoft.com
+  allowList: `youtube.com
   `.replace(regStrip, "")
 };
 
@@ -184,7 +181,7 @@ function validate() {
   var valid = true;
   var status = document.getElementById("status");
   document
-    .getElementById("blacklist")
+    .getElementById("allowList")
     .value.split("\n")
     .forEach((match) => {
       match = match.replace(regStrip, "");
@@ -193,7 +190,7 @@ function validate() {
           var regexp = new RegExp(match);
         } catch (err) {
           status.textContent =
-            "Error: Invalid blacklist regex: " + match + ". Unable to save";
+            "Error: Invalid allowList regex: " + match + ". Unable to save";
           valid = false;
           return;
         }
@@ -218,7 +215,7 @@ function save_options() {
   var enabled = document.getElementById("enabled").checked;
   var startHidden = document.getElementById("startHidden").checked;
   var controllerOpacity = document.getElementById("controllerOpacity").value;
-  var blacklist = document.getElementById("blacklist").value;
+  var allowList = document.getElementById("allowList").value;
 
   chrome.storage.sync.remove([
     "resetSpeed",
@@ -242,7 +239,7 @@ function save_options() {
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
       keyBindings: keyBindings,
-      blacklist: blacklist.replace(regStrip, "")
+      allowList: allowList.replace(regStrip, "")
     },
     function () {
       // Update status to let user know options were saved.
@@ -265,7 +262,7 @@ function restore_options() {
     document.getElementById("startHidden").checked = storage.startHidden;
     document.getElementById("controllerOpacity").value =
       storage.controllerOpacity;
-    document.getElementById("blacklist").value = storage.blacklist;
+    document.getElementById("allowList").value = storage.allowList;
 
     // ensure that there is a "display" binding for upgrades from versions that had it as a separate binding
     if (storage.keyBindings.filter((x) => x.action == "display").length == 0) {


### PR DESCRIPTION
Changed the blacklist to an allowlist, letting users opt-in to sites explicitly. Added Youtube to the initial offering. Changed settings page to indicate this. Did not version bump.

Note that settings appear out of sync and show everything previously in the blacklist to be in the allowlist. This can be addressed by saving the settings with the appropriate details or deleting the temporary files associated with the extension prior to reinstalling. New downloads will not be affected.